### PR TITLE
improved(password rules): Added a USPS rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The _Password Manager Resources_ project exists so creators of password managers
 "Quirk" is a term from web browser development that refers to a website-specific, hard-coded behavior to work around an issue with a website that can't be fixed in a principled, universal way. In this project, it has the same meaning. Although ideally, the industry will work to eliminate the need for all of the quirks in this project, there's value in customizing behaviors to ensure better user experience. The current quirks are:
 
 * [**Password Rules**](#password-rules): Rules to generate compatible passwords with websites' particular requirements.
-* [**Websites with Shared Credential Backends**](#websites-with-shared-credential-backends): Groups of websites known to use the same credential backend, which can be used to enhance suggested credentials to sign in to websites.
+* [**Shared Credentials**](#shared-credentials): Groups of websites known to use the same credential backend, which can be used to enhance suggested credentials to sign in to websites.
 * [**Change Password URLs**](#change-password-urls): To drive the adoption of strong passwords, it's useful to be able to take users directly to websites' change password pages.
 * [**Websites Where 2FA Code is Appended to Password**](#websites-where-2fa-code-is-appended-to-password): Some websites use a two-factor authentication scheme where the user must append a generated code to their password when signing in.
 

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -135,6 +135,7 @@
     "twitch.tv": "https://www.twitch.tv/settings/security",
     "udacity.com": "https://classroom.udacity.com/settings/password",
     "udel.edu": "https://udapps.nss.udel.edu/myUDsettings/password",
+    "uml.edu": "https://mypassword.uml.edu/#Change",
     "umsystem.edu": "https://password.umsystem.edu/reset/",
     "usaa.com": "https://www.usaa.com/inet/ent_auth_password/pages/ChangePasswordPage",
     "ventrachicago.com": "https://www.ventrachicago.com/account/manage-account/",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -106,6 +106,7 @@
     "redirect.pizza": "https://redirect.pizza/profile",
     "reelgood.com": "https://reelgood.com/account",
     "rejsekort.dk": "https://selvbetjening.rejsekort.dk/CWS/CustomerManagement/ChangePassword",
+    "ruc.dk": "https://pwrecovery.ruc.dk",
     "santahelenasaude.com.br": "https://www.santahelenasaude.com.br/beneficiario/#/alterar-senha",
     "saturn.de": "https://www.saturn.de/webapp/wcs/stores/servlet/MultiChannelMAChangePassword",
     "secure.orclinic.com": "https://secure.orclinic.com/portal/editprofile.aspx",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -90,6 +90,7 @@
     "nytimes.com": "https://myaccount.nytimes.com/seg/profile",
     "orcid.org": "https://orcid.org/account",
     "overleaf.com": "https://www.overleaf.com/user/settings",
+    "app.parkmobile.io": "https://app.parkmobile.io/account/settings",
     "patreon.com": "https://www.patreon.com/settings/profile",
     "paypal.com": "https://www.paypal.com/myaccount/security/password/change",
     "pilotflyingj.com": "https://portal.pilotflyingj.com/myrewards/forgot-password",

--- a/quirks/change-password-URLs.json
+++ b/quirks/change-password-URLs.json
@@ -3,6 +3,7 @@
     "1800contacts.com": "https://www.1800contacts.com/account/settings",
     "500px.com": "https://web.500px.com/settings/account/security",
     "aa.com": "https://www.aa.com/loyalty/profile/information",
+    "account.magento.com": "https://account.magento.com/customer/account/changepassword",
     "account.publishing.service.gov.uk": "https://www.account.publishing.service.gov.uk/account/edit/password",
     "acorns.com": "https://app.acorns.com/settings/change-password",
     "adobe.com": "https://account.adobe.com/security",

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -242,6 +242,9 @@
     "epicmix.com": {
         "password-rules": "minlength: 8; maxlength: 16;"
     },
+    "equifax.com": {
+        "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit; required: [!$*+@];"
+    },
     "essportal.excelityglobal.com": {
         "password-rules": "minlength: 6; maxlength: 8; allowed: lower, upper, digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -392,6 +392,9 @@
     "live.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "lloydsbank.co.uk" : {
+        "passwordrules" : "minlength: 8; maxlength: 15; required: lower; required: digit; allowed: upper;"
+    },
     "lowes.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower, upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -689,6 +689,9 @@
     "web.de": {
         "password-rules": "minlength: 8; maxlength: 40; allowed: lower, upper, digit, [-<=>~!|()@#{}$%,.?^'&*_+`:;\"[]];"
     },
+    "wegmans.com": {
+        "password-rules": "minlength: 8; required: digit; required: upper,lower; required: [!#$%&*+=?@^];"
+    },
     "weibo.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -479,7 +479,7 @@
     "packageconciergeadmin.com": {
         "password-rules": "minlength: 4; maxlength: 4; allowed: digit;"
     },
-    "parkmobile.io": {
+    "app.parkmobile.io": {
         "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@#$%^&];"
     },
     "paypal.com": {

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -554,6 +554,9 @@
     "rogers.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; required: [!@#$];"
     },
+    "ruc.dk": {
+        "password-rules": "minlength: 6; maxlength: 8; required: lower, upper; required: [-!#%&(){}*+;%/<=>?_];"
+    },
     "runescape.com": {
         "password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -569,6 +569,9 @@
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },
+    "salslimo.com": {
+        "password-rules": "minlength: 8; maxlength: 50; required: upper; required: lower; required: digit; required: [!@#$&*];"
+    },
     "santahelenasaude.com.br": {
         "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: [-!@#$%&*_+=<>];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -270,7 +270,7 @@
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
     "fidelity.com": {
-        "minlength: 6; maxlength: 20; required: lower; allowed: upper,digit,[!$%'()+,./:;=?@\^_|~];"
+        "password-rules": "minlength: 6; maxlength: 20; required: lower; allowed: upper,digit,[!$%'()+,./:;=?@\^_|~];"
     },
     "flysas.com": {
         "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -515,6 +515,9 @@
     "prepaid.bankofamerica.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [!@#$%^&*()+~{}'\";:<>?];"
     },
+    "prestocard.ca": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit,[!\"#$%&'()*+,<>?@];"
+    },
     "propelfuels.com": {
         "password-rules": "minlength: 6; maxlength: 16;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -701,6 +701,9 @@
     "xfinity.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; required: digit;"
     },
+    "xvoucher.com": {
+        "password-rules": "minlength: 11; required: upper; required: digit; required: [!@#$%&_];"
+    },
     "yatra.com": {
         "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&'()+,.:?@[_`~]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -47,6 +47,9 @@
     "anthem.com": {
         "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!$*?@|];"
     },
+    "app.digio.in": {
+        "password-rules": "minlength: 8; maxlength: 15;"
+    },
     "apple.com": {
         "password-rules": "minlength: 8; maxlength: 63; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -650,6 +650,9 @@
     "visa.com": {
         "password-rules": "minlength: 6; maxlength: 32;"
     },
+    "visabenefits-auth.axa-assistance.us": {
+        "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!\"#$%&()*,.:<>?@^{|}];"
+    },
     "vivo.com.br": {
         "password-rules": "maxlength: 6; max-consecutive: 3; allowed: digit;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -80,6 +80,9 @@
     "bcassessment.ca": {
         "password-rules": "minlength: 8; maxlength: 14;"
     },
+    "belkin.com": {
+        "password-rules": "minlength: 8; required: lower, upper; required: digit; required: [$!@~_,%&];"
+    },
     "benefitslogin.discoverybenefits.com": {
         "password-rules": "minlength: 10; required: upper; required: digit; required: [!#$%&*?@]; allowed: lower;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -185,6 +185,9 @@
     "dailymail.co.uk": {
         "password-rules": "minlength: 5; maxlength: 15;"
     },
+    "dan.org": {
+        "password-rules": "minlength: 8; maxlength: 25; required: lower; required: upper; required: digit; required: [!@$%^&*];"
+    },
     "danawa.com": {
         "password-rules": "minlength: 8; maxlength: 21; required: lower, upper; required: digit; required: [!@$%^&*];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -566,6 +566,9 @@
     "secure.orclinic.com": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower; required: digit; allowed: ascii-printable;"
     },
+    "secure.snnow.ca": {
+        "password-rules": "minlength: 7; maxlength: 16; required: digit; allowed: lower, upper;"
+    },
     "secure.wa.aaa.com": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; allowed: ascii-printable;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -545,6 +545,9 @@
     "rogers.com": {
         "password-rules": "minlength: 8; required: lower, upper; required: digit; required: [!@#$];"
     },
+    "runescape.com": {
+        "password-rules": "minlength: 5; maxlength: 20; required: lower; required: upper; required: digit;"
+    },
     "ruten.com.tw": {
         "password-rules": "minlength: 6; maxlength: 15; required: lower, upper;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -269,6 +269,9 @@
     "fedex.com": {
         "password-rules": "minlength: 8; max-consecutive: 3; required: lower; required: upper; required: digit; allowed: [-!@#$%^&*_+=`|(){}[:;,.?]];"
     },
+    "fidelity.com": {
+        "minlength: 6; maxlength: 20; required: lower; allowed: upper,digit,[!$%'()+,./:;=?@\^_|~];"
+    },
     "flysas.com": {
         "password-rules": "minlength: 8; maxlength: 14; required: lower; required: upper; required: digit; required: [-~!@#$%^&_+=`|(){}[:\"'<>,.?]];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -641,6 +641,9 @@
     "thameswater.co.uk": {
         "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: special;"
     },
+    "training.confluent.io": {
+        "password-rules": "minlength: 6; maxlength: 16; required: lower; required: upper; required: digit; allowed: [!#$%*@^_~];"
+    },
     "twitter.com": {
         "password-rules": "minlength: 8;"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -313,7 +313,10 @@
     },
     "hkbea.com": {
         "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
-    },    
+    },
+    "hkexpress.com" : {
+        "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit; required: special;"
+    },
     "hotels.com": {
         "password-rules": "minlength: 6; maxlength: 20; required: digit; allowed: lower, upper, [@$!#()&^*%];"
     },

--- a/quirks/password-rules.json
+++ b/quirks/password-rules.json
@@ -431,6 +431,9 @@
     "maybank2u.com.my": {
         "password-rules": "minlength: 8; maxlength: 12; max-consecutive: 2; required: lower; required: upper; required: digit; required: [-~!@#$%^&*_+=`|(){}[:;\"'<>,.?];"
     },
+    "medicare.gov": {
+                "password-rules": "minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [@!$%^*()];"
+    }, 
     "metlife.com": {
         "password-rules": "minlength: 6; maxlength: 20;"
     },

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -79,6 +79,15 @@
     },
     {
         "from": [
+            "flyblade.com"
+        ],
+        "to": [
+            "blade.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    }
+    {
+        "from": [
             "discordapp.com"
         ],
         "to": [

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -1,6 +1,20 @@
 [
     {
         "shared": [
+            "3docean.net",
+            "audiojungle.net",
+            "codecanyon.net",
+            "envato.com",
+            "graphicriver.net",
+            "photodune.net",
+            "placeit.net",
+            "themeforest.net",
+            "tutsplus.com",
+            "videohive.net"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -160,6 +160,12 @@
     },
     {
         "shared": [
+            "uspowerboating.com",
+            "ussailing.org"
+        ]
+    },
+    {
+        "shared": [
             "wikipedia.org",
             "mediawiki.org",
             "wikibooks.org",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -188,6 +188,15 @@
         ]
     },
     {
+        "from": [
+            "www.vistaprint.ca"
+        ],
+        "to": [
+            "account.vistaprint.com"
+        ],
+        "fromDomainsAreObsoleted": true
+    },
+    {
         "shared": [
             "wikipedia.org",
             "mediawiki.org",

--- a/quirks/shared-credentials.json
+++ b/quirks/shared-credentials.json
@@ -15,6 +15,21 @@
     },
     {
         "shared": [
+            "albertsons.com",
+            "acmemarkets.com",
+            "carrsqc.com",
+            "jewelosco.com",
+            "pavilions.com",
+            "randalls.com",
+            "safeway.com",
+            "shaws.com",
+            "starmarket.com",
+            "tomthumb.com",
+            "vons.com"
+        ]
+    },
+    {
+        "shared": [
             "airbnb.com.ar",
             "airbnb.com.au",
             "airbnb.at",
@@ -85,7 +100,7 @@
             "blade.com"
         ],
         "fromDomainsAreObsoleted": true
-    }
+    },
     {
         "from": [
             "discordapp.com"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -523,6 +523,10 @@
         "unitedwifi.com"
     ],
     [
+        "uspowerboating.com",
+        "ussailing.org"
+    ],
+    [
         "verizon.com",
         "verizonwireless.com",
         "vzw.com"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -1,5 +1,17 @@
 [
     [
+        "3docean.net",
+        "audiojungle.net",
+        "codecanyon.net",
+        "envato.com",
+        "graphicriver.net",
+        "photodune.net",
+        "placeit.net",
+        "themeforest.net",
+        "tutsplus.com",
+        "videohive.net"
+    ],
+    [
         "aa.com",
         "americanairlines.com",
         "americanairlines.jp"

--- a/quirks/websites-with-shared-credential-backends.json
+++ b/quirks/websites-with-shared-credential-backends.json
@@ -86,6 +86,19 @@
         "airnewzealand.com.au"
     ],
     [
+        "albertsons.com",
+        "acmemarkets.com",
+        "carrsqc.com",
+        "jewelosco.com",
+        "pavilions.com",
+        "randalls.com",
+        "safeway.com",
+        "shaws.com",
+        "starmarket.com",
+        "tomthumb.com",
+        "vons.com"
+    ],
+    [
         "alltrails.com",
         "alltrails.io"
     ],
@@ -287,6 +300,10 @@
     [
         "fandangonow.com",
         "fandango.com"
+    ],
+    [
+        "flyblade.com",
+        "blade.com"
     ],
     [
         "fnac.com",
@@ -598,5 +615,9 @@
     [
         "wsj.com",
         "dowjones.com"
+    ],
+    [
+        "www.vistaprint.ca",
+        "account.vistaprint.com"
     ]
 ]


### PR DESCRIPTION
<!-- Thanks for contributing! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]); you should remove sections for files you aren't changing -->

### Overall Checklist
- [x] I agree to the project's [Developer Certificate of Origin](https://github.com/apple/password-manager-resources/blob/main/DEVELOPER_CERTIFICATE_OF_ORIGIN.md)
- [x] The top-level JSON objects are sorted alphabetically
- [x] There are no [open pull requests](https://github.com/apple/password-manager-resources/pulls) for the same update

#### for password-rules.json
- [x] The given rule isn't particularly standard and obvious for password managers
- [x] Generated passwords have been tested from this rule using the [Password Rules Validation Tool](https://developer.apple.com/password-rules/)
- [x] Information has been included about the website's requirements (eg. screenshots, error messages, steps during experimentation, etc.)
- [x] The PR isn't documenting something that would be a common practice among password managers (e.g. minimal length of 6)

![image](https://user-images.githubusercontent.com/29067983/139066997-d86f2d5e-4016-42aa-8391-93b67295324b.png)

I checked the passwords generated with this rule both on https://developer.apple.com/password-rules/ and with 1Password, and the generated passwords work great.